### PR TITLE
Add basic Next.js auth example

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,30 @@
-# codex-test
-testing chat gpt codex test
+# Fullstack Site Example
+
+This repository contains a basic full stack example using **Next.js**, **React**, **Tailwind CSS**, and **MySQL**. It includes:
+
+- API routes for signing up and logging in users.
+- An admin page that lists all users.
+- Simple pages for signing up and logging in.
+
+## Setup
+
+1. Install dependencies:
+
+```bash
+npm install
+```
+
+2. Configure database connection via environment variables:
+
+- `DB_HOST`
+- `DB_USER`
+- `DB_PASS`
+- `DB_NAME`
+
+3. Run the development server:
+
+```bash
+npm run dev
+```
+
+Navigate to `http://localhost:3000` to see the site.

--- a/lib/db.js
+++ b/lib/db.js
@@ -1,0 +1,11 @@
+import mysql from 'mysql2/promise'
+
+export async function getConnection() {
+  const connection = await mysql.createConnection({
+    host: process.env.DB_HOST || 'localhost',
+    user: process.env.DB_USER || 'root',
+    password: process.env.DB_PASS || '',
+    database: process.env.DB_NAME || 'testdb',
+  })
+  return connection
+}

--- a/next-env.d.ts
+++ b/next-env.d.ts
@@ -1,0 +1,5 @@
+/// <reference types="next" />
+/// <reference types="next/image-types/global" />
+
+// NOTE: This file should not be edited
+// see https://nextjs.org/docs/basic-features/typescript for more information.

--- a/next.config.js
+++ b/next.config.js
@@ -1,0 +1,6 @@
+/** @type {import('next').NextConfig} */
+const nextConfig = {
+  reactStrictMode: true,
+}
+
+module.exports = nextConfig

--- a/package.json
+++ b/package.json
@@ -1,0 +1,22 @@
+{
+  "name": "fullstack-site",
+  "version": "1.0.0",
+  "scripts": {
+    "dev": "next dev",
+    "build": "next build",
+    "start": "next start"
+  },
+  "dependencies": {
+    "next": "13.4.7",
+    "react": "18.2.0",
+    "react-dom": "18.2.0",
+    "mysql2": "^3.3.0",
+    "bcryptjs": "^2.4.3"
+  },
+  "devDependencies": {
+    "autoprefixer": "^10.4.14",
+    "postcss": "^8.4.24",
+    "tailwindcss": "^3.3.2",
+    "typescript": "^5.0.4"
+  }
+}

--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -1,0 +1,6 @@
+import '../styles/globals.css'
+import type { AppProps } from 'next/app'
+
+export default function MyApp({ Component, pageProps }: AppProps) {
+  return <Component {...pageProps} />
+}

--- a/pages/admin.tsx
+++ b/pages/admin.tsx
@@ -1,0 +1,35 @@
+import { useEffect, useState } from 'react'
+import { useRouter } from 'next/router'
+
+interface User {
+  id: number
+  email: string
+}
+
+export default function Admin() {
+  const [users, setUsers] = useState<User[]>([])
+  const router = useRouter()
+
+  useEffect(() => {
+    fetch('/api/users?admin=true')
+      .then((res) => {
+        if (res.status === 401) {
+          router.push('/login')
+          return null
+        }
+        return res.json()
+      })
+      .then((data) => data && setUsers(data))
+  }, [router])
+
+  return (
+    <div className="p-8">
+      <h1 className="text-2xl font-bold mb-4">Admin</h1>
+      <ul className="list-disc pl-5">
+        {users.map((u) => (
+          <li key={u.id}>{u.email}</li>
+        ))}
+      </ul>
+    </div>
+  )
+}

--- a/pages/api/login.js
+++ b/pages/api/login.js
@@ -1,0 +1,15 @@
+import { getConnection } from '../../lib/db'
+import bcrypt from 'bcryptjs'
+
+export default async function handler(req, res) {
+  if (req.method !== 'POST') return res.status(405).end()
+  const { email, password } = req.body
+  const conn = await getConnection()
+  const [rows] = await conn.execute('SELECT id, password, isAdmin FROM users WHERE email = ?', [email])
+  await conn.end()
+  if (!rows.length) return res.status(401).json({ message: 'Invalid credentials' })
+  const user = rows[0]
+  const isValid = await bcrypt.compare(password, user.password)
+  if (!isValid) return res.status(401).json({ message: 'Invalid credentials' })
+  res.status(200).json({ id: user.id, email, isAdmin: !!user.isAdmin })
+}

--- a/pages/api/signup.js
+++ b/pages/api/signup.js
@@ -1,0 +1,19 @@
+import { getConnection } from '../../lib/db'
+import bcrypt from 'bcryptjs'
+
+export default async function handler(req, res) {
+  if (req.method !== 'POST') return res.status(405).end()
+  const { email, password } = req.body
+  if (!email || !password) return res.status(400).json({ message: 'Missing fields' })
+  const hashed = await bcrypt.hash(password, 10)
+  const conn = await getConnection()
+  await conn.execute('CREATE TABLE IF NOT EXISTS users (id INT AUTO_INCREMENT PRIMARY KEY, email VARCHAR(255) UNIQUE, password VARCHAR(255), isAdmin BOOLEAN DEFAULT FALSE)')
+  try {
+    await conn.execute('INSERT INTO users (email, password) VALUES (?, ?)', [email, hashed])
+    res.status(201).json({ message: 'User created' })
+  } catch (err) {
+    res.status(500).json({ message: 'Error creating user' })
+  } finally {
+    await conn.end()
+  }
+}

--- a/pages/api/users.js
+++ b/pages/api/users.js
@@ -1,0 +1,10 @@
+import { getConnection } from '../../lib/db'
+
+export default async function handler(req, res) {
+  const { admin } = req.query
+  if (admin !== 'true') return res.status(401).json({ message: 'Unauthorized' })
+  const conn = await getConnection()
+  const [rows] = await conn.execute('SELECT id, email FROM users')
+  await conn.end()
+  res.status(200).json(rows)
+}

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -1,0 +1,14 @@
+import Link from 'next/link'
+
+export default function Home() {
+  return (
+    <div className="p-8">
+      <h1 className="text-2xl font-bold mb-4">Welcome</h1>
+      <div className="space-x-4">
+        <Link href="/signup" className="text-blue-600 underline">Sign Up</Link>
+        <Link href="/login" className="text-blue-600 underline">Log In</Link>
+        <Link href="/admin" className="text-blue-600 underline">Admin</Link>
+      </div>
+    </div>
+  )
+}

--- a/pages/login.tsx
+++ b/pages/login.tsx
@@ -1,0 +1,45 @@
+import { useState } from 'react'
+import { useRouter } from 'next/router'
+
+export default function Login() {
+  const [email, setEmail] = useState('')
+  const [password, setPassword] = useState('')
+  const router = useRouter()
+
+  async function handleSubmit(e: React.FormEvent) {
+    e.preventDefault()
+    const res = await fetch('/api/login', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ email, password }),
+    })
+    if (res.ok) {
+      router.push('/admin')
+    } else {
+      alert('Invalid credentials')
+    }
+  }
+
+  return (
+    <div className="p-8 max-w-md mx-auto">
+      <h1 className="text-2xl font-bold mb-4">Log In</h1>
+      <form onSubmit={handleSubmit} className="space-y-4">
+        <input
+          type="email"
+          placeholder="Email"
+          value={email}
+          onChange={(e) => setEmail(e.target.value)}
+          className="border p-2 w-full"
+        />
+        <input
+          type="password"
+          placeholder="Password"
+          value={password}
+          onChange={(e) => setPassword(e.target.value)}
+          className="border p-2 w-full"
+        />
+        <button type="submit" className="bg-blue-600 text-white px-4 py-2">Log In</button>
+      </form>
+    </div>
+  )
+}

--- a/pages/signup.tsx
+++ b/pages/signup.tsx
@@ -1,0 +1,45 @@
+import { useState } from 'react'
+import { useRouter } from 'next/router'
+
+export default function Signup() {
+  const [email, setEmail] = useState('')
+  const [password, setPassword] = useState('')
+  const router = useRouter()
+
+  async function handleSubmit(e: React.FormEvent) {
+    e.preventDefault()
+    const res = await fetch('/api/signup', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ email, password }),
+    })
+    if (res.ok) {
+      router.push('/login')
+    } else {
+      alert('Signup failed')
+    }
+  }
+
+  return (
+    <div className="p-8 max-w-md mx-auto">
+      <h1 className="text-2xl font-bold mb-4">Sign Up</h1>
+      <form onSubmit={handleSubmit} className="space-y-4">
+        <input
+          type="email"
+          placeholder="Email"
+          value={email}
+          onChange={(e) => setEmail(e.target.value)}
+          className="border p-2 w-full"
+        />
+        <input
+          type="password"
+          placeholder="Password"
+          value={password}
+          onChange={(e) => setPassword(e.target.value)}
+          className="border p-2 w-full"
+        />
+        <button type="submit" className="bg-blue-600 text-white px-4 py-2">Sign Up</button>
+      </form>
+    </div>
+  )
+}

--- a/postcss.config.js
+++ b/postcss.config.js
@@ -1,0 +1,6 @@
+module.exports = {
+  plugins: {
+    tailwindcss: {},
+    autoprefixer: {},
+  },
+}

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -1,0 +1,3 @@
+@tailwind base;
+@tailwind components;
+@tailwind utilities;

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -1,0 +1,11 @@
+/** @type {import('tailwindcss').Config} */
+module.exports = {
+  content: [
+    './pages/**/*.{js,ts,jsx,tsx}',
+    './components/**/*.{js,ts,jsx,tsx}',
+  ],
+  theme: {
+    extend: {},
+  },
+  plugins: [],
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,20 @@
+{
+  "compilerOptions": {
+    "target": "es5",
+    "lib": ["dom", "dom.iterable", "esnext"],
+    "allowJs": true,
+    "skipLibCheck": true,
+    "strict": false,
+    "forceConsistentCasingInFileNames": true,
+    "noEmit": true,
+    "esModuleInterop": true,
+    "module": "esnext",
+    "moduleResolution": "node",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "jsx": "preserve",
+    "incremental": true
+  },
+  "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx"],
+  "exclude": ["node_modules"]
+}


### PR DESCRIPTION
## Summary
- set up Next.js app with TypeScript and Tailwind
- add pages for login, signup and admin
- create API routes backed by MySQL
- document setup

## Testing
- `npm run build` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6847f0d51638832c98cee521ea1b9192